### PR TITLE
added an example to call performance command.

### DIFF
--- a/magellan.json
+++ b/magellan.json
@@ -1,0 +1,5 @@
+{
+  "reporters": [
+    "./node_modules/testarmada-performance-reporter/lib/performance_reporter"
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "dependencies": {
     "nightwatch": "^0.7.9",
     "testarmada-magellan": "1.6.6",
-    "testarmada-magellan-nightwatch": "1.5.1",
+    "testarmada-magellan-nightwatch": "1.5.3",
     "testarmada-performance-reporter": "1.1.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "nightwatch": "^0.7.9",
     "testarmada-magellan": "1.6.6",
-    "testarmada-magellan-nightwatch": "1.5.1"
+    "testarmada-magellan-nightwatch": "1.5.1",
+    "testarmada-performance-reporter": "1.1.1"
   }
 }

--- a/tests/walmart-book.js
+++ b/tests/walmart-book.js
@@ -1,11 +1,19 @@
 var Test = require("../lib/example-base-test-class");
-
+var url = "http://www.walmart.com/search/?query=sam%20walton%20made%20in%20america";
 module.exports = new Test({
 
   "Search for Sam Walton Book": function (client) {
     client
       .resizeWindow(1280, 1024)
-      .url("http://www.walmart.com/search/?query=sam%20walton%20made%20in%20america")
+      .url(url)
+      .getPerformance(function (result) {
+        // Send a message to Magellan about this page
+        process.send({
+          type: "performance-metrics",
+          url: url,
+          metrics: result
+        });
+      })
   },
 
   "Check product description": function (client) {


### PR DESCRIPTION
This can be executed with command `magellan --browser firefox` . Chrome is sometimes giving me negative numbers, still working on it.  This is example requetsed  for PR #18 in magellan-nightwatch repo. Here is how the result should look like 

```
============= Suite Complete =============

     Status: PASSED
    Runtime: 14.4s
Total tests: 2
 Successful: 2 / 2

---------------------------------------
Gathered performance metrics: 
---------------------------------------

url: http://www.walmart.com/search/?query=sam%20walton%20made%20in%20america
metrics:
[
  "DomContentLoad: 0.525 seconds",
  "Page Load (onLoad): 3.973 seconds",
  "Full Page Load: 3.16 seconds",
  "Number of Requests: 92",
  "First Paint: 0 seconds"

]
```
