### PR TITLE
demo with true magellan-nightwatch page object

### DIFF
--- a/lib/pages/demo-first.js
+++ b/lib/pages/demo-first.js
@@ -39,8 +39,8 @@ module.exports = {
     jumpToSecondDemo: function () {
       var link = this.section.jumptoseconddemo;
       link
-        .waitForElementVisible('@link')
-        .click('@link');
+        .getEl('@link')
+        .clickEl('@link');
 
       return this;
     }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "drydock": "^0.4.3",
     "nightwatch": "^0.8.9",
     "testarmada-magellan": "^4.0.1",
-    "testarmada-magellan-nightwatch": "^3.0.0",
+    "testarmada-magellan-nightwatch": "3.1.0-beta",
     "testarmada-performance-reporter": "2.0.0",
     "yargs": "1.3.2"
   }

--- a/tests/demo-page-object.js
+++ b/tests/demo-page-object.js
@@ -28,10 +28,10 @@ module.exports = new Test({
     var ds = client.page["demo-second"]();
 
     ds.section.beijing
-      .waitForElementVisible('@title')
-      .assert.containsText("@title", "Beijing")
-      .assert.containsText("@description", "China")
-      .assert.containsText("@content", "It is the most populous city in the China");
+      .getEl('@title')
+      .assert.elContainsText("@title", "Beijing")
+      .assert.elContainsText("@description", "China")
+      .assert.elContainsText("@content", "It is the most populous city in the China");
 
     client.end();
   }


### PR DESCRIPTION
Convert all commands and assertions used in demo to customized counterparts to demonstrate page object support of magellan-nightwatch. 
