### PR TITLE
fix nightly build failure

### DIFF
--- a/lib/example-base-test-class.js
+++ b/lib/example-base-test-class.js
@@ -20,7 +20,8 @@ var MyExampleBaseClass = function (steps) {
 util.inherits(MyExampleBaseClass, Base);
 
 MyExampleBaseClass.prototype = {
-  before: function (client) {
+  before: function (client, callback) {
+    Base.prototype.before.call(this, client);
 
     this.client.drydock =
       getDrydock(
@@ -29,7 +30,7 @@ MyExampleBaseClass.prototype = {
 
     this.client.drydock.start(function () {
       // call super-after
-      Base.prototype.before.call(this, client);
+      callback();
     });
 
   },

--- a/tests/demo-page-object.js
+++ b/tests/demo-page-object.js
@@ -2,6 +2,8 @@ var Test = require("../lib/example-base-test-class");
 var dpro = require("dpro");
 
 module.exports = new Test({
+  tags: ["pageobject"],
+
   "Load demo first page": function(client) {
     var df = client.page["demo-first"]();
 


### PR DESCRIPTION
move prototype.before to first line in base test to keep a healthy execution order
