### PR TITLE
Adding eslint to boilerplate example

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To lint your files, simply run the below command from the root of the boilerplat
 npm run automation-lint
 ```
 
-All `.js` and `.json` files inside `lib` and `tests` will be linted as per the rules defined in `/conf/eslint/.eslintrc-base`.
+All `.js` and `.json` files inside `lib` and `tests` will be linted as per the rules defined in `conf/eslint/.eslintrc-base`.
 
 Notes
 =====

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To lint your files, simply run the below command from the root of the boilerplat
 npm run automation-lint
 ```
 
-All the JS and JSON files inside lib/ and tests/ folders will be linted as per the rules defined inside `/conf/eslint/.eslintrc-base`.
+All `.js` and `.json` files inside `lib` and `tests will be linted as per the rules defined in `/conf/eslint/.eslintrc-base`.
 
 Notes
 =====

--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ For more information on how to run tests, including in different browsers, in pa
 
 To start developing your own tests, look at `tests/*` and `lib/example-base-test-class.js`.
 
+
+Linting
+========
+
+To lint your files, simply run the below command from the root of the boilerplate project
+```console
+npm run automation-lint
+```
+
+All the JS and JSON files inside lib/ and tests/ folders will be linted as per the rules defined inside `/conf/eslint/.eslintrc-base`.
+
 Notes
 =====
 

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ To lint your files, simply run the below command from the root of the boilerplat
 npm run automation-lint
 ```
 
-All `.js` and `.json` files inside `lib` and `tests will be linted as per the rules defined in `/conf/eslint/.eslintrc-base`.
+All `.js` and `.json` files inside `lib` and `tests` will be linted as per the rules defined in `/conf/eslint/.eslintrc-base`.
 
 Notes
 =====

--- a/conf/eslint/.eslintrc-base
+++ b/conf/eslint/.eslintrc-base
@@ -1,0 +1,10 @@
+---
+extends:
+  - "eslint-config-defaults/configurations/walmart/es5-node"
+
+rules:
+  "filenames/filenames": 0                      # disable checking of file names
+  "no-magic-numbers": 0                         # disable checking of magic numbers
+  "strict": [2, "never"]                        # disable checking of "require strict"
+  "newline-after-var": [2, "always"]            # new line required after variable declarations
+  "no-multiple-empty-lines": [2, {"max": 1}]    # no multiple empty lines

--- a/lib/example-base-test-class.js
+++ b/lib/example-base-test-class.js
@@ -37,6 +37,7 @@ MyExampleBaseClass.prototype = {
 
   after: function (client, callback) {
     var self = this;
+
     this.client.drydock.stop(function () {
       // call super-after
       Base.prototype.after.call(self, client, callback);
@@ -47,7 +48,7 @@ MyExampleBaseClass.prototype = {
   // it is not enumerable (since it's on the prototype)
   getSiteURL: function () {
     return this.client.launchUrl + ":" + argv.mocking_port;
-}
+  }
 };
 
 module.exports = MyExampleBaseClass;

--- a/lib/pages/demo-first.js
+++ b/lib/pages/demo-first.js
@@ -38,9 +38,10 @@ module.exports = {
   commands: [{
     jumpToSecondDemo: function () {
       var link = this.section.jumptoseconddemo;
+
       link
-        .getEl('@link')
-        .clickEl('@link');
+        .getEl("@link")
+        .clickEl("@link");
 
       return this;
     }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,9 @@
   },
   "author": "",
   "license": "MIT",
+  "scripts": {
+    "automation-lint": "eslint --ext .js,.json -c conf/eslint/.eslintrc-base lib tests"
+  },
   "dependencies": {
     "chromedriver": "^2.21.2",
     "drydock": "^0.4.3",
@@ -25,5 +28,10 @@
     "testarmada-magellan-nightwatch-plugin": "^5.0.0",
     "yargs": "1.3.2",
     "dpro": "^1.0.0"
+  },
+  "devDependencies": {
+    "eslint": "^1.10.3",
+    "eslint-config-defaults": "^7.1.1",
+    "eslint-plugin-filenames": "^0.1.2"
   }
 }

--- a/tests/demo-page-object.js
+++ b/tests/demo-page-object.js
@@ -4,7 +4,7 @@ var dpro = require("dpro");
 module.exports = new Test({
   tags: ["pageobject"],
 
-  "Load demo first page": function(client) {
+  "Load demo first page": function (client) {
     var df = client.page["demo-first"]();
 
     df
@@ -13,31 +13,32 @@ module.exports = new Test({
       .api.resizeWindow(1200, 800);
   },
 
-  "Verify all cities on first page": function(client) {
+  "Verify all cities on first page": function (client) {
     var df = client.page["demo-first"]();
+
     // no need to call `navigate`
     df
       .assert.elContainsText("#tokyo", "Tokyo")
       .assert.elContainsText(".city:eq(1) p:eq(1)", "Europe");
   },
 
-  "Jump to demo second page": function(client) {
+  "Jump to demo second page": function (client) {
     client
       .page["demo-first"]()
       .jumpToSecondDemo();
   },
 
-  "Verify cities on second page": function(client) {
+  "Verify cities on second page": function (client) {
     var ds = client.page["demo-second"]();
 
     ds.section.beijing
-      .getEl('@title')
+      .getEl("@title")
       .assert.elContainsText("#beijing", "Beijing")
       .assert.elContainsText("@description", "China")
       .assert.elContainsText("@content", "It is the most populous city in the China");
   },
 
-  "Verify cities on second page - performance improvement": function(client) {
+  "Verify cities on second page - performance improvement": function (client) {
     var ds = client.page["demo-second"]();
     var beijing = ds.section.beijing;
 
@@ -51,10 +52,10 @@ module.exports = new Test({
         "It is the most populous city in the China");
   },
 
-  "Verify cities on second page - maintenance improvement": function(client) {
+  "Verify cities on second page - maintenance improvement": function (client) {
     var ds = client.page["demo-second"]();
     var beijing = ds.section.beijing;
-    
+
     beijing
       .getEl(beijing.elements.title.selector)
       .assert.elContainsText(beijing.elements.title.selector,


### PR DESCRIPTION
This PR adds `eslint` to the boilerplate-nightwatch example.

To run eslint on the test files, simply do `npm run automation-lint`.

ReadME and existing lint issues are also fixed.

@Maciek416 @geekdave 
