### PR TITLE
Updated selenium-server version

### DIFF
--- a/conf/nightwatch.json
+++ b/conf/nightwatch.json
@@ -15,7 +15,7 @@
 
   "selenium": {
     "start_process": true,
-    "server_path": "./node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.0.jar",
+    "server_path": "./node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.1.jar",
     "log_path": "reports",
     "host": "127.0.0.1",
     "port": 4444,

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "drydock": "^0.4.3",
     "nightwatch": "^0.8.9",
     "phantomjs": "^2.1.3",
-    "selenium-server": "^2.53.0",
+    "selenium-server": "2.53.1",
     "testarmada-magellan": "^8.7.1",
     "testarmada-nightwatch-extra": "^2.0.0",
     "testarmada-magellan-nightwatch-plugin": "^5.0.0",


### PR DESCRIPTION
I set the version in the package.json static and updated the nightwatch.conf to the latest selenium-server version, to avoid:

``` bash
Error: Unable to access jarfile ./node_modules/selenium-server/lib/runner/selenium-server-standalone-2.53.0.jar
```
