### PR TITLE
Add asyncHookTimeout to nightwatch configuration

### DIFF
--- a/conf/nightwatch.json
+++ b/conf/nightwatch.json
@@ -40,7 +40,8 @@
         "browserName": "chrome"
       },
       "globals": {
-        "waitForConditionTimeout": 60000
+        "waitForConditionTimeout": 60000,
+        "asyncHookTimeout": 60000
       }
     },
 


### PR DESCRIPTION
In high parallelism situations, some of our users have trouble surviving nightwatch's `10000ms` default async hook timeout during `before` or `beforeEach`, especially in larger filled out apps that push more network content over the wire. This default which is aligned with our command timeout recommendation of `60000ms` should help.

/cc @archlichking @ThaiWood @geekdave 
