### PR TITLE
add bloop reporter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: node_js
 
 script:
-  - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --profile=https://api.myjson.com/bins/e0u2z#default
+  - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --profile=http://geekdave.com/profiles.json#default
 
 node_js:
   - v7

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ script:
   - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --browsers=$TIER_1_2_BROWSERS
 
 env:
-  - TIER_1_2_BROWSERS=
+  - | 
+  TIER_1_2_BROWSERS=
   chrome_latest_Windows_10_Desktop,
   firefox_latest_Windows_10_Desktop,
   safari_7_OS_X_10_9_Desktop,

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,10 @@ node_js:
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/
 sudo: false
 
+addons:
+  hosts:
+    - travis.dev
+
 before_install:
   # ensure latest npm installed.
   - npm install -g npm
@@ -20,5 +24,7 @@ before_install:
   - export MAGELLAN_BUILD_NAME=${TRAVIS_JOB_ID}_${TRAVIS_JOB_NUMBER}
   - export MAGELLAN_BUILD_ID=`date +%s`
   - export SAUCE_TUNNEL_ID=${TRAVIS_JOB_ID}_${TRAVIS_JOB_NUMBER}
+  - export MOCK_HOSTNAME=travis.dev
+
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,14 @@ script:
   - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --browsers=$TIER_1_2_BROWSERS
 
 env:
-  - TIER_1_2_BROWSERS=chrome_latest_Windows_2012_R2_Desktop,firefox_46_Windows_2012_R2_Desktop,IE_11_Windows_2012_R2_Desktop,safari_7_OS_X_10_9_Desktop,IE_8_Windows_2008_Desktop,IE_9_Windows_2008_Desktop,IE_10_Windows_2012_Desktop
+  - TIER_1_2_BROWSERS=
+  chrome_latest_Windows_10_Desktop,
+  firefox_latest_Windows_10_Desktop,
+  safari_7_OS_X_10_9_Desktop,
+  IE_8_Windows_2008_Desktop,
+  IE_9_Windows_2008_Desktop,
+  IE_10_Windows_2012_Desktop,
+  IE_11_Windows_2012_R2_Desktop
 
 node_js:
   - v7

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,7 @@
 language: node_js
 
 script:
-  - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --browsers=$TIER_1_2_BROWSERS
-
-env:
-  - | 
-  TIER_1_2_BROWSERS=
-  chrome_latest_Windows_10_Desktop,
-  firefox_latest_Windows_10_Desktop,
-  safari_7_OS_X_10_9_Desktop,
-  IE_8_Windows_2008_Desktop,
-  IE_9_Windows_2008_Desktop,
-  IE_10_Windows_2012_Desktop,
-  IE_11_Windows_2012_R2_Desktop
+  - DPRO=local ./node_modules/.bin/magellan --sauce --create_tunnels --external_build_id=$TRAVIS_BUILD_ID --bail_time=${MAGELLAN_INDIVIDUAL_TEST_BAIL_TIME} --profile=https://api.myjson.com/bins/e0u2z#default
 
 node_js:
   - v7

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,10 +7,10 @@ env:
   - TIER_1_2_BROWSERS=chrome_latest_Windows_2012_R2_Desktop,firefox_46_Windows_2012_R2_Desktop,IE_11_Windows_2012_R2_Desktop,safari_7_OS_X_10_9_Desktop,IE_8_Windows_2008_Desktop,IE_9_Windows_2008_Desktop,IE_10_Windows_2012_Desktop
 
 node_js:
-  - "node"
-  - "iojs"
-  - "0.12"
-  - "0.10"
+  - v7
+  - v6
+  - v5
+  - v4
 
 # Use container-based Travis infrastructure.
 # See: http://docs.travis-ci.com/user/workers/container-based-infrastructure/

--- a/lib/pages/demo-first.js
+++ b/lib/pages/demo-first.js
@@ -4,7 +4,7 @@ module.exports = {
   url: function () {
     return url.format({
       protocol: "http",
-      hostname: this.api.drydock.ip,
+      hostname: MOCK_HOSTNAME || this.api.drydock.ip,
       port: this.api.drydock.port,
       pathname: "/demo-first"
     });

--- a/lib/pages/demo-first.js
+++ b/lib/pages/demo-first.js
@@ -4,7 +4,7 @@ module.exports = {
   url: function () {
     return url.format({
       protocol: "http",
-      hostname: MOCK_HOSTNAME || this.api.drydock.ip,
+      hostname: process.env.MOCK_HOSTNAME || this.api.drydock.ip,
       port: this.api.drydock.port,
       pathname: "/demo-first"
     });

--- a/lib/pages/demo-second.js
+++ b/lib/pages/demo-second.js
@@ -4,7 +4,7 @@ module.exports = {
   url: function () {
     return url.format({
       protocol: "http",
-      hostname: this.api.drydock.ip,
+      hostname: process.env.MOCK_HOSTNAME || this.api.drydock.ip,
       port: this.api.drydock.port,
       pathname: "/demo-second"
     });

--- a/magellan.json
+++ b/magellan.json
@@ -1,3 +1,6 @@
 {
+  "reporters": [
+    "magellan-bloop"
+  ],
   "framework": "testarmada-magellan-nightwatch-plugin"
 }

--- a/magellan.json
+++ b/magellan.json
@@ -1,6 +1,6 @@
 {
   "reporters": [
-    "magellan-bloop"
+    "testarmada-bloop"
   ],
   "framework": "testarmada-magellan-nightwatch-plugin"
 }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "selenium-server": "^3.0.1",
     "testarmada-magellan": "^8.7.1",
     "testarmada-nightwatch-extra": "^2.0.0",
+    "testarmada-bloop": "^0.0.2",
     "testarmada-magellan-nightwatch-plugin": "^5.0.0",
     "yargs": "6.6.0",
     "dpro": "^1.0.0"


### PR DESCRIPTION
This adds the bloop reporter to the boilerplate project so we can get public-facing stats on public-facing tests.  Using a bloop server deployed in Azure for now.  Server name and details are configured with private travis variables so we can restrict it to only authorized jobs.